### PR TITLE
Small changes to support Windows

### DIFF
--- a/flickrbox.py
+++ b/flickrbox.py
@@ -304,7 +304,7 @@ class FlickrboxEventHandler(watchdog.events.FileSystemEventHandler):
         """
         Returns a dictionary containing the photoset title and photo title of a given filepath
         """
-        parsed = file_path.split('/')
+        parsed = file_path.split(os.sep)
         photo_parsed = os.path.splitext(parsed[-1])
         return {
             "photoset": parsed[-2],

--- a/flickrbox.py
+++ b/flickrbox.py
@@ -26,7 +26,7 @@ class Flickrbox:
 
     def __init__(self, dirname="FlickrBox", path=Path.home(), sync=False):
         self.dirname = dirname
-        self.path = "%s/%s" % (path, dirname)
+        self.path = os.path.join(path, dirname)
 
         self._upload_tickets = {}
         self._user = None
@@ -260,7 +260,7 @@ class Flickrbox:
         """
         Returns the absolute path based on given arguments
         """
-        return "%s/%s/%s%s" % (self.path, photoset_title, photo_title, file_ext)
+        return os.path.join(self.path, photoset_title, "%s%s" % (photo_title, file_ext))
 
 
 class FlickrboxEventHandler(watchdog.events.FileSystemEventHandler):


### PR DESCRIPTION
By using os.path.join() rather than straight string interpolation, FlickrBox can work on Windows as well as Linux.